### PR TITLE
Make readers load from a LineNumberReader instead of a List<String>

### DIFF
--- a/src/main/java/net/neoforged/srgutils/InternalUtils.java
+++ b/src/main/java/net/neoforged/srgutils/InternalUtils.java
@@ -48,7 +48,6 @@ class InternalUtils {
             reader.reset();
             return loadProguard(reader).build();
         } else if (firstLine.startsWith("v1\t")) { // Tiny V1
-            reader.reset();
             return loadTinyV1(firstLine, reader).build();
         } else if (firstLine.startsWith("tiny\t")) { // Tiny V2+
             return loadTinyV2(firstLine, reader).build();

--- a/src/main/java/net/neoforged/srgutils/InternalUtils.java
+++ b/src/main/java/net/neoforged/srgutils/InternalUtils.java
@@ -32,12 +32,12 @@ class InternalUtils {
         reader.mark(2048);
 
         String firstLine;
-		do {
-			firstLine = reader.readLine();
-			if (firstLine == null) {
-				return IMappingBuilder.create().build();
-			}
-		} while (stripComment(firstLine).isEmpty());
+        do {
+            firstLine = reader.readLine();
+            if (firstLine == null) {
+                return IMappingBuilder.create().build();
+            }
+        } while (stripComment(firstLine).isEmpty());
 
         String test = firstLine.split(" ")[0];
 
@@ -429,9 +429,9 @@ class InternalUtils {
             reader.mark(2048);
             String[] line = reader.readLine().split("\t");
             if (!line[0].isEmpty()) {
-				reader.reset();
+                reader.reset();
                 break;
-			}
+            }
 
             properties.put(line[1], line.length < 3 ? null : escaped ? unescapeTinyString(line[2]) : line[2]);
             if ("escaped-names".equals(line[1]))

--- a/src/main/java/net/neoforged/srgutils/InternalUtils.java
+++ b/src/main/java/net/neoforged/srgutils/InternalUtils.java
@@ -29,10 +29,10 @@ class InternalUtils {
 
     static INamedMappingFile loadNamed(InputStream in) throws IOException {
         LineNumberReader reader = new LineNumberReader(new InputStreamReader(in));
-        reader.mark(2048);
 
         String firstLine;
         do {
+            reader.mark(2048);
             firstLine = reader.readLine();
             if (firstLine == null) {
                 return IMappingBuilder.create().build();

--- a/src/main/java/net/neoforged/srgutils/InternalUtils.java
+++ b/src/main/java/net/neoforged/srgutils/InternalUtils.java
@@ -156,6 +156,9 @@ class InternalUtils {
 
         IMappingBuilder.IClass cls = null;
         for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+            if (line.isEmpty() || stripComment(line).isEmpty()) {
+                continue;
+            }
             line = line.replace('.', '/');
             if (!line.startsWith("    ") && line.endsWith(":")) {
                 String[] pts = line.replace('.', '/').split(" -> ");

--- a/src/main/java/net/neoforged/srgutils/InternalUtils.java
+++ b/src/main/java/net/neoforged/srgutils/InternalUtils.java
@@ -46,7 +46,7 @@ class InternalUtils {
             return loadSRG(filter(collectLines(reader))).build();
         } else if(firstLine.contains(" -> ")) { // ProGuard
             reader.reset();
-            return loadProguard(filter(collectLines(reader))).build();
+            return loadProguard(reader).build();
         } else if (firstLine.startsWith("v1\t")) { // Tiny V1
             reader.reset();
             return loadTinyV1(collectLines(reader)).build();
@@ -151,11 +151,11 @@ class InternalUtils {
      *     10:15 boolean oldFunction(java.lang.Objeect,int[]) -> newFunction
      *
      */
-    private static IMappingBuilder loadProguard(List<String> lines) throws IOException {
+    private static IMappingBuilder loadProguard(LineNumberReader reader) throws IOException {
         IMappingBuilder ret = IMappingBuilder.create("left", "right");
 
         IMappingBuilder.IClass cls = null;
-        for (String line : lines) {
+        for (String line = reader.readLine(); line != null; line = reader.readLine()) {
             line = line.replace('.', '/');
             if (!line.startsWith("    ") && line.endsWith(":")) {
                 String[] pts = line.replace('.', '/').split(" -> ");

--- a/src/main/java/net/neoforged/srgutils/InternalUtils.java
+++ b/src/main/java/net/neoforged/srgutils/InternalUtils.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +29,7 @@ class InternalUtils {
     }
 
     static INamedMappingFile loadNamed(InputStream in) throws IOException {
-        LineNumberReader reader = new LineNumberReader(new InputStreamReader(in));
+        LineNumberReader reader = new LineNumberReader(new InputStreamReader(in, StandardCharsets.UTF_8));
 
         String firstLine;
         do {

--- a/src/test/java/net/neoforged/srgutils/test/MappingTest.java
+++ b/src/test/java/net/neoforged/srgutils/test/MappingTest.java
@@ -105,25 +105,25 @@ public class MappingTest {
         ), Files.readAllLines(output));
     }
 
-    @Test
-    void tsrg2() throws IOException {
-        IMappingFile map = INamedMappingFile.load(getStream("./tsrg2.tsrg")).getMap("a", "b");
-        IMappingFile.IClass aaeaa = map.getClass("aae$a$a");
-        assertEquals("net/test/src/C_5218_", aaeaa.getMapped());
-        assertEquals("deserialize", aaeaa.getMethod(
-                "a",
-                "(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Laae$a;"
+	@Test
+	void tsrg2() throws IOException {
+		IMappingFile map = INamedMappingFile.load(getStream("./tsrg2.tsrg")).getMap("a", "b");
+		IMappingFile.IClass aaeaa = map.getClass("aae$a$a");
+		assertEquals("net/test/src/C_5218_", aaeaa.getMapped());
+		assertEquals("deserialize", aaeaa.getMethod(
+				"a",
+				"(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Laae$a;"
 		).getMapped());
-    }
+	}
 
-    @Test
-    void tinyV1() throws IOException {
-        IMappingFile map = INamedMappingFile.load(getStream("./tiny_v1.tiny")).getMap("a", "b");
-        IMappingFile.IClass aaeaa = map.getClass("a");
-        assertEquals("net/test/class_4581", aaeaa.getMapped());
-        assertEquals("method_22848", aaeaa.getMethod(
-                "a",
-                "(FF)Lcom/mojang/datafixers/util/Pair;"
+	@Test
+	void tinyV1() throws IOException {
+		IMappingFile map = INamedMappingFile.load(getStream("./tiny_v1.tiny")).getMap("a", "b");
+		IMappingFile.IClass aaeaa = map.getClass("a");
+		assertEquals("net/test/class_4581", aaeaa.getMapped());
+		assertEquals("method_22848", aaeaa.getMethod(
+				"a",
+				"(FF)Lcom/mojang/datafixers/util/Pair;"
 		).getMapped());
-    }
+	}
 }

--- a/src/test/java/net/neoforged/srgutils/test/MappingTest.java
+++ b/src/test/java/net/neoforged/srgutils/test/MappingTest.java
@@ -117,6 +117,13 @@ public class MappingTest {
 	}
 
 	@Test
+	void tsrg2ExceptionLineNumber() {
+		IOException ioException = assertThrows(IOException.class, () ->
+				INamedMappingFile.load(getStream("./tsrg2_invalid.tsrg")));
+		assertTrue(ioException.getMessage().startsWith("Invalid TSRG v2 line (#4)"));
+	}
+
+	@Test
 	void tinyV1() throws IOException {
 		IMappingFile map = INamedMappingFile.load(getStream("./tiny_v1.tiny")).getMap("a", "b");
 		IMappingFile.IClass aaeaa = map.getClass("a");

--- a/src/test/java/net/neoforged/srgutils/test/MappingTest.java
+++ b/src/test/java/net/neoforged/srgutils/test/MappingTest.java
@@ -104,4 +104,18 @@ public class MappingTest {
                 "\tc\tbaz"
         ), Files.readAllLines(output));
     }
+
+    @Test
+    void tsrg2() throws IOException {
+        IMappingFile map = INamedMappingFile.load(getStream("./tsrg2.tsrg")).getMap("a", "b");
+        IMappingFile.IClass aaeaa = map.getClass("aae$a$a");
+        assertEquals("net/test/src/C_5218_", aaeaa.getMapped());
+    }
+
+    @Test
+    void tinyV1() throws IOException {
+        IMappingFile map = INamedMappingFile.load(getStream("./tiny_v1.tiny")).getMap("a", "b");
+        IMappingFile.IClass aaeaa = map.getClass("a");
+        assertEquals("net/test/class_4581", aaeaa.getMapped());
+    }
 }

--- a/src/test/java/net/neoforged/srgutils/test/MappingTest.java
+++ b/src/test/java/net/neoforged/srgutils/test/MappingTest.java
@@ -110,6 +110,10 @@ public class MappingTest {
         IMappingFile map = INamedMappingFile.load(getStream("./tsrg2.tsrg")).getMap("a", "b");
         IMappingFile.IClass aaeaa = map.getClass("aae$a$a");
         assertEquals("net/test/src/C_5218_", aaeaa.getMapped());
+        assertEquals("deserialize", aaeaa.getMethod(
+                "a",
+                "(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Laae$a;"
+		).getMapped());
     }
 
     @Test
@@ -117,5 +121,9 @@ public class MappingTest {
         IMappingFile map = INamedMappingFile.load(getStream("./tiny_v1.tiny")).getMap("a", "b");
         IMappingFile.IClass aaeaa = map.getClass("a");
         assertEquals("net/test/class_4581", aaeaa.getMapped());
+        assertEquals("method_22848", aaeaa.getMethod(
+                "a",
+                "(FF)Lcom/mojang/datafixers/util/Pair;"
+		).getMapped());
     }
 }

--- a/src/test/resources/tiny_v1.tiny
+++ b/src/test/resources/tiny_v1.tiny
@@ -1,0 +1,22 @@
+v1	a	b
+CLASS	a	net/test/class_4581
+FIELD	a	F	a	field_21633
+FIELD	a	F	b	field_21634
+METHOD	a	()V	a	method_22847
+METHOD	a	(F)V	a	method_23729
+METHOD	a	(FF)Lcom/mojang/datafixers/util/Pair;	a	method_22848
+METHOD	a	(FFF)Lcom/mojang/datafixers/util/Pair;	a	method_22849
+METHOD	a	(IIF)V	a	method_26288
+METHOD	a	(La;)V	a	method_22852
+METHOD	a	(Ld;)V	a	method_23274
+METHOD	a	()Lorg/apache/commons/lang3/tuple/Triple;	b	method_22853
+METHOD	a	(FFF)La;	b	method_23963
+METHOD	a	(La;)V	b	method_22855
+METHOD	a	()V	c	method_22856
+METHOD	a	(La;)Ld;	c	method_22857
+METHOD	a	()La;	d	method_23296
+METHOD	a	()F	e	method_23731
+METHOD	a	(Ljava/lang/Object;)Z	equals	equals
+METHOD	a	()Z	f	method_23732
+METHOD	a	()I	hashCode	hashCode
+METHOD	a	()Ljava/lang/String;	toString	toString

--- a/src/test/resources/tsrg2.tsrg
+++ b/src/test/resources/tsrg2.tsrg
@@ -1,0 +1,19 @@
+tsrg2 a b id
+a net/test/src/C_140945_ 140945
+	a f_142767_ 142767
+	b f_142768_ 142768
+	<init> ()V <init> 142771
+aad net/test/src/C_5215_ 5215
+	a f_134885_ 134885
+	<clinit> ()V <clinit> 134887
+		static
+	<init> (Lqx;)V <init> 179833
+		0 o p_179834_ 179834
+	a (Lqx;)V m_5779_ 134898
+		0 o p_134899_ 134899
+aae$a$a net/test/src/C_5218_ 5218
+	<init> ()V <init> 134928
+	a (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Laae$a; deserialize 134929
+		0 o p_134930_ 134930
+		1 o p_134931_ 134931
+		2 o p_134932_ 134932

--- a/src/test/resources/tsrg2_invalid.tsrg
+++ b/src/test/resources/tsrg2_invalid.tsrg
@@ -1,0 +1,6 @@
+tsrg2 a b id
+a net/test/src/C_140945_ 140945
+	a f_142767_ 142767
+INVALID
+	b f_142768_ 142768
+	<init> ()V <init> 142771


### PR DESCRIPTION
Some mapping files can be quite large so this saves on memory use while loading them.

Currently implements:
ProGuard
TinyV2
TinyV1
SRG
TSRG v2
(all readers except TSRG/CSRG)